### PR TITLE
fix:CalendarServiceForFixTest

### DIFF
--- a/backend/src/main/kotlin/com/ll/TeamProject/domain/calendar/service/CalendarService.kt
+++ b/backend/src/main/kotlin/com/ll/TeamProject/domain/calendar/service/CalendarService.kt
@@ -5,6 +5,7 @@ import com.ll.TeamProject.domain.calendar.dto.CalendarUpdateDto
 import com.ll.TeamProject.domain.calendar.entity.Calendar
 import com.ll.TeamProject.domain.calendar.repository.CalendarRepository
 import com.ll.TeamProject.global.exceptions.ServiceException
+import com.ll.TeamProject.global.userContext.UserContext
 import com.ll.TeamProject.global.userContext.UserContextService
 import jakarta.transaction.Transactional
 import org.slf4j.Logger
@@ -16,7 +17,8 @@ import org.springframework.stereotype.Service
 class CalendarService(
     private val calendarRepository: CalendarRepository,
     private val userContextService: UserContextService,
-    private val calendarOwnerValidator: CalendarOwnerValidator
+    private val calendarOwnerValidator: CalendarOwnerValidator,
+    private val userContext: UserContext
 ) {
 
     private val log: Logger = LoggerFactory.getLogger(CalendarService::class.java)
@@ -27,7 +29,7 @@ class CalendarService(
 
     // 캘린더 생성
     fun createCalendar(dto: CalendarCreateDto): Calendar {
-        val user = userContextService.getAuthenticatedUser()
+        val user = userContext.findActor() ?: throw ServiceException("401", "인증된 사용자를 찾을 수 없습니다.")
         val calendar = Calendar(user, dto.name, dto.description)
         val savedCalendar = calendarRepository.save(calendar)
 


### PR DESCRIPTION
## CalendarServiceForFixTest

캘린더 생성 시, 사이트유저DB조회하는것으로 변경
- 프론트랑 직접 연결된 코드가 많아서 빠른 수정방법을 채택

캘린더 엔티티노출은 추 후 수정 예정 
- 프론트랑 연결된게 있어서 확인해봐야함